### PR TITLE
Dont Auto Build Game Packages in Debug Mode

### DIFF
--- a/VectorRumble.Desktop/VectorRumble.Desktop.csproj
+++ b/VectorRumble.Desktop/VectorRumble.Desktop.csproj
@@ -23,6 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <PlatformTarget>x64</PlatformTarget>
+    <AutoBuildPackages>false</AutoBuildPackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>


### PR DESCRIPTION
The Packaging Nuget will auto build the various game platform packages by default. So in debug mode we need to make sure we don't do that. 

This is done by setting the `AutoBuildPackages` property to `False` in the `Debug` configuration in the csproj. Only the Desktop csproj uses the Packaging Nuget so its the only project that needs to be modified. 