### PR TITLE
fix: optimize LINQ operations to reduce GC pressure (#59)

### DIFF
--- a/VectorRumble.Core/Gameplay/ShipManager.cs
+++ b/VectorRumble.Core/Gameplay/ShipManager.cs
@@ -14,15 +14,61 @@ namespace VectorRumble
         private Ship[] ships;
         public List<Ship> SelectedPlayers = new List<Ship>();
 
+        // Cached arrays for performance
+        private Ship[] cachedAvailableShips;
+        private Ship[] cachedPlayers;
+        private Ship[] cachedSpareShips;
+        private bool cachesDirty = true;
+
         public ShipManager(World world)
         {
             this.world = world;
         }
 
-        public Ship[] AvailableShips => Ships.Where(s => !string.IsNullOrEmpty(s.PlayerIndex)).OrderBy(p => p.PlayerStringToIndex).ToArray();
-        public Ship[] Players => Ships.Where(s => s.Playing).ToArray();
+        public Ship[] AvailableShips 
+        {
+            get 
+            {
+                if (cachesDirty)
+                    UpdateCaches();
+                return cachedAvailableShips;
+            }
+        }
+
+        public Ship[] Players 
+        {
+            get 
+            {
+                if (cachesDirty)
+                    UpdateCaches();
+                return cachedPlayers;
+            }
+        }
+
         public Ship[] Ships { get { return ships; } }
-        public Ship[] SpareShips => Ships.Where(s => string.IsNullOrEmpty(s.PlayerIndex)).ToArray();
+        
+        public Ship[] SpareShips 
+        {
+            get 
+            {
+                if (cachesDirty)
+                    UpdateCaches();
+                return cachedSpareShips;
+            }
+        }
+
+        private void UpdateCaches()
+        {
+            cachedAvailableShips = Ships.Where(s => !string.IsNullOrEmpty(s.PlayerIndex)).OrderBy(p => p.PlayerStringToIndex).ToArray();
+            cachedPlayers = Ships.Where(s => s.Playing).ToArray();
+            cachedSpareShips = Ships.Where(s => string.IsNullOrEmpty(s.PlayerIndex)).ToArray();
+            cachesDirty = false;
+        }
+
+        public void InvalidateCaches()
+        {
+            cachesDirty = true;
+        }
 
         internal void LoadContent(ContentManager content)
         {
@@ -47,6 +93,7 @@ namespace VectorRumble
                     ships[i] = ship;
                 }
             }
+            InvalidateCaches();
         }
 
         public void UpdateSelectedList()
@@ -59,6 +106,7 @@ namespace VectorRumble
                     SelectedPlayers.Add(ship);
                 }
             }
+            InvalidateCaches();
         }
     }
 }

--- a/VectorRumble.Core/Screens/GameplayScreen.cs
+++ b/VectorRumble.Core/Screens/GameplayScreen.cs
@@ -164,7 +164,6 @@ namespace VectorRumble
 
             spriteBatch.Begin();
 
-            Ship[] ships = null;
             Vector2 size;
 
             foreach (var index in playerIndexes)
@@ -173,7 +172,7 @@ namespace VectorRumble
                 var caps = GamePad.GetState(index);
 
                 // Only Draw Join message if no one is playing yet.
-                if (!World.ShipManager.Players.Any())
+                if (World.ShipManager.Players.Length == 0)
                 {
                     switch (index)
                     {
@@ -195,16 +194,31 @@ namespace VectorRumble
                     }
                 }
 
-                if (World.ShipManager.SelectedPlayers.Any()) {
-                    ships = World.ShipManager.SelectedPlayers.Where(p => p.PlayerStringToIndex == index).ToArray();
+                Ship playerShip = null;
+                if (World.ShipManager.SelectedPlayers.Count > 0) {
+                    foreach (var ship in World.ShipManager.SelectedPlayers)
+                    {
+                        if (ship.PlayerStringToIndex == index)
+                        {
+                            playerShip = ship;
+                            break;
+                        }
+                    }
                 }
 
-                if (World.ShipManager.Players.Any()) {
-                    ships = World.ShipManager.Players.Where(p => p.PlayerStringToIndex == index).ToArray();
+                if (World.ShipManager.Players.Length > 0 && playerShip == null) {
+                    foreach (var ship in World.ShipManager.Players)
+                    {
+                        if (ship.PlayerStringToIndex == index)
+                        {
+                            playerShip = ship;
+                            break;
+                        }
+                    }
                 }
 
-                if (ships != null && ships.Length > 0) {
-                    message = string.Format(Strings.Score, ships[0].Name, ships[0].Score);
+                if (playerShip != null) {
+                    message = string.Format(Strings.Score, playerShip.Name, playerShip.Score);
                 }
 
                 size = spriteFont.MeasureString(message) * scale;

--- a/VectorRumble.Core/Screens/OptionsMenuScreen.cs
+++ b/VectorRumble.Core/Screens/OptionsMenuScreen.cs
@@ -35,7 +35,7 @@ namespace VectorRumble
 			};
         static int currentAsteroidDensity = 2;
 
-        static string[] arenas => World.ArenaManager.Arenas.Select(a => a.Name).ToArray();
+        static string[] arenas;
         static int blurIntensity = 5;
         static bool controllersCanShootInAllDirections;
         static string currentArena = string.Empty;
@@ -65,6 +65,12 @@ namespace VectorRumble
         /// </summary>
         public OptionsMenuScreen()
         {
+            // Cache the arenas array on first initialization
+            if (arenas == null)
+            {
+                arenas = World.ArenaManager.Arenas.Select(a => a.Name).ToArray();
+            }
+
             blurIntensity = WorldRules.BlurIntensity;
             controllersCanShootInAllDirections = WorldRules.ControllersCanShootInAllDirections;
             currentArena = WorldRules.DefaultArena;

--- a/VectorRumble.Core/Screens/ShipSelectionScreen.cs
+++ b/VectorRumble.Core/Screens/ShipSelectionScreen.cs
@@ -36,7 +36,7 @@ namespace VectorRumble
                 ExitScreen();
             }
 
-            if (input.MenuSelect && World.ShipManager.SelectedPlayers.Any())
+            if (input.MenuSelect && World.ShipManager.SelectedPlayers.Count > 0)
             {
                 var arenaSelection = new ArenaSelectionScreen
                 {

--- a/VectorRumble.Core/Simulation/World.cs
+++ b/VectorRumble.Core/Simulation/World.cs
@@ -119,7 +119,7 @@ namespace VectorRumble
         /// All ships that might enter the game.
         /// </summary>
         [ContentSerializer(SharedResource = true)]
-        public Ship[] Ships => ShipManager.Ships.ToArray();
+        public Ship[] Ships => ShipManager.Ships;
 
         public ShipManager ShipManager { get; set; }
         public ArenaManager ArenaManager { get; set; }
@@ -234,7 +234,8 @@ namespace VectorRumble
         {
             var ws = WorldRules.DefaultArena;
 			if (ws == Strings.Arena_Random) {
-                ws = ArenaManager.Arenas.ToArray()[random.Next(0, ArenaManager.Arenas.Length - 1)].Name;
+                var arenas = ArenaManager.Arenas;
+                ws = arenas[random.Next(0, arenas.Length - 1)].Name;
 			}
             selectedArena = ArenaManager.Arenas.First(a => a.Name == ws);
         }


### PR DESCRIPTION
- ShipManager: Cache filtered arrays (AvailableShips, Players, SpareShips) with lazy invalidation
- World: Remove unnecessary .ToArray() calls on Ships property and arena selection
- GameplayScreen: Replace .Any() with .Count/.Length checks and optimize player ship lookups
- ShipSelectionScreen: Replace .Any() with .Count check
- OptionsMenuScreen: Cache arenas array instead of recomputing with LINQ

These changes eliminate unnecessary allocations in hot paths like the game loop, reducing garbage collection pressure and improving performance.